### PR TITLE
Add get_[min|max]_value() functions and clamp the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An external ESPHome component to control a boiler (or other supported HVAC appli
 
 We aim for maximum flexibility in this component by exposing most of the information available through the OpenTherm protocol, while allowing all configuration in YAML. (No custom component code required!) Since every boiler and every situation is different, you have to play around a bit with the sensors you'd want to read. There is no requirement for a boiler to support everything in the protocol, so not every sensor in this component will work with your boiler. (For example, my Remeha Avanta does not report `ch_pressure`, `dhw_flow_rate` or `t_dhw`.) <!-- #2: We try to be smart about this and not send request messages for these if the boiler consistently indicates it doesn't understand the message or the data is unavailable. You'll find warning messages indicating this behaviour in the ESPHome logs. -->
 
-This component uses [@ihormelnyk's OpenTherm Library](https://github.com/ihormelnyk/opentherm_library) (MIT licensed) as its communication layer. The message loop is inspired by code for the [DIYLESS ESP32 Wi-Fi Thermostat](https://github.com/diyless/esp32-wifi-thermostat) (MIT licensed).
+This component a uses modified version of [@Jiří Praus' OpenTherm Library](https://github.com/jpraus/arduino-opentherm) (creative Commons licensed) as its communication layer. The message loop is inspired by code for the [DIYLESS ESP32 Wi-Fi Thermostat](https://github.com/diyless/esp32-wifi-thermostat) (MIT licensed).
 
 Alternatives:
 - [ESPHome-OpenTherm by @rsciriano](https://github.com/rsciriano/ESPHome-OpenTherm), a custom component based on the same library as this project
@@ -213,6 +213,8 @@ The boiler can also report several numerical values, which are available through
 - `t_flow_ch2`: Flow water temperature CH2 circuit (°C)
 - `t_dhw2`: Domestic hot water temperature 2 (°C)
 - `t_exhaust`: Boiler exhaust temperature (°C)
+- `fan_speed`: Boiler fan speed (RPM)
+- `flame_current`: Boiler flame current (µA)
 - `burner_starts`: Number of starts burner
 - `ch_pump_starts`: Number of starts CH pump
 - `dhw_pump_valve_starts`: Number of starts DHW pump/valve

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An external ESPHome component to control a boiler (or other supported HVAC appli
 
 We aim for maximum flexibility in this component by exposing most of the information available through the OpenTherm protocol, while allowing all configuration in YAML. (No custom component code required!) Since every boiler and every situation is different, you have to play around a bit with the sensors you'd want to read. There is no requirement for a boiler to support everything in the protocol, so not every sensor in this component will work with your boiler. (For example, my Remeha Avanta does not report `ch_pressure`, `dhw_flow_rate` or `t_dhw`.) <!-- #2: We try to be smart about this and not send request messages for these if the boiler consistently indicates it doesn't understand the message or the data is unavailable. You'll find warning messages indicating this behaviour in the ESPHome logs. -->
 
-This component a uses modified version of [@Jiří Praus' OpenTherm Library](https://github.com/jpraus/arduino-opentherm) (creative Commons licensed) as its communication layer. The message loop is inspired by code for the [DIYLESS ESP32 Wi-Fi Thermostat](https://github.com/diyless/esp32-wifi-thermostat) (MIT licensed).
+This component a uses modified version of [@Jiří Praus' OpenTherm Library](https://github.com/jpraus/arduino-opentherm) (Creative Commons licensed) as its communication layer. The message loop is inspired by code for the [DIYLESS ESP32 Wi-Fi Thermostat](https://github.com/diyless/esp32-wifi-thermostat) (MIT licensed).
 
 Alternatives:
 - [ESPHome-OpenTherm by @rsciriano](https://github.com/rsciriano/ESPHome-OpenTherm), a custom component based on the same library as this project

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The following switches are available:
 
 <!-- BEGIN schema_docs:switch -->
 - `ch_enable`: Central Heating enabled  
-  Defaults to *True*
+  Defaults to *False*
 - `dhw_enable`: Domestic Hot Water enabled  
-  Defaults to *True*
+  Defaults to *False*
 - `cooling_enable`: Cooling enabled  
   Defaults to *False*
 - `otc_active`: Outside temperature compensation active  

--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -1,3 +1,4 @@
+#include <algorithm> // Some compilers may need this for std::clamp
 #include "output.h"
 
 namespace esphome {
@@ -5,7 +6,7 @@ namespace opentherm {
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD("opentherm.output", "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
-  this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : min_value_ + state * (max_value_ - min_value_);
+  this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : std::clamp(min_value_ + state * (max_value_ - min_value_), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD("opentherm.output", "Output %s set to %.2f", this->id_, this->state);
 }

--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -1,4 +1,4 @@
-#include <algorithm> // Some compilers may need this for std::clamp
+#include "esphome/core/helpers.h" // for clamp()
 #include "output.h"
 
 namespace esphome {
@@ -6,7 +6,7 @@ namespace opentherm {
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD("opentherm.output", "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
-  this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : std::clamp(min_value_ + state * (max_value_ - min_value_), min_value_, max_value_);
+  this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(min_value_ + state * (max_value_ - min_value_), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD("opentherm.output", "Output %s set to %.2f", this->id_, this->state);
 }

--- a/components/opentherm/output/output.h
+++ b/components/opentherm/output/output.h
@@ -25,6 +25,8 @@ class OpenthermOutput : public output::FloatOutput, public Component, public Ope
 
   void set_min_value(float min_value) override { this->min_value_ = min_value; }
   void set_max_value(float max_value) override { this->max_value_ = max_value; }
+  float get_min_value() { return this->min_value_; }
+  float get_max_value() { return this->max_value_; }
 };
 
 }  // namespace opentherm

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -5,8 +5,12 @@ from typing import Generic, TypeVar, TypedDict, Optional
 
 from esphome.const import (
     UNIT_CELSIUS,
+    UNIT_MICROAMP,
     UNIT_PERCENT,
+    UNIT_REVOLUTIONS_PER_MINUTE,
     DEVICE_CLASS_COLD,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_HEAT,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_PROBLEM,
@@ -562,6 +566,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_0",
+                "default_mode": "restore_default_on"
             }
         ),
         "dhw_enable": SwitchSchema(
@@ -570,6 +575,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_1",
+                "default_mode": "restore_default_on"
             }
         ),
         "cooling_enable": SwitchSchema(
@@ -578,6 +584,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_2",
+                "default_mode": "restore_default_off"
             }
         ),
         "otc_active": SwitchSchema(
@@ -586,6 +593,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_3",
+                "default_mode": "restore_default_off"
             }
         ),
         "ch2_active": SwitchSchema(
@@ -594,6 +602,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_4",
+                "default_mode": "restore_default_off"
             }
         ),
     }

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -566,7 +566,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_0",
-                "default_mode": "restore_default_on"
+                "default_mode": "restore_default_off"
             }
         ),
         "dhw_enable": SwitchSchema(
@@ -575,7 +575,7 @@ SWITCHES: Schema[SwitchSchema] = Schema(
                 "message": "STATUS",
                 "keep_updated": True,
                 "message_data": "flag8_hb_1",
-                "default_mode": "restore_default_on"
+                "default_mode": "restore_default_off"
             }
         ),
         "cooling_enable": SwitchSchema(


### PR DESCRIPTION
I have need for get_min_value() and get_max_value() for some lambdas that I use with my boiler.
The output value also benefits from being clamped to the min/max value for better control over the flow temperature. Without it, I was finding the flow temperature to be overshooting the max value.

Also tweaked the schema.py and updated the README - I realise that this will disappear once (if ?) the code is merged with esphome. Until then, it doesn't hurt to keep local documentation up to date.