### PR TITLE
Rework output function to interpolate between min|max limits.

### DIFF
--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -1,4 +1,4 @@
-#include "esphome/core/helpers.h" // for clamp()
+#include "esphome/core/helpers.h" // for clamp() and lerp()
 #include "output.h"
 
 namespace esphome {
@@ -6,9 +6,8 @@ namespace opentherm {
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD("opentherm.output", "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
-  state = remap(state, min_value_, max_value_, 0, 1);
-  state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(state, 0, 1);
-  this->state = lerp(state, min_value_, max_value_);
+  state = state < 0.003 && this->zero_means_zero_ ? 0.0 : lerp(state, min_value_, max_value_);
+  this->state = clamp(state, min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD("opentherm.output", "Output %s set to %.2f", this->id_, this->state);
 }

--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -6,7 +6,9 @@ namespace opentherm {
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD("opentherm.output", "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
-  this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(min_value_ + state * (max_value_ - min_value_), min_value_, max_value_);
+  state = remap(state, min_value_, max_value_, 0, 1);
+  state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(state, 0, 1);
+  this->state = lerp(state, min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD("opentherm.output", "Output %s set to %.2f", this->id_, this->state);
 }


### PR DESCRIPTION
Never been happy with the way output was calculated. arthurrump's routine would overshoot max_value.
My original revision clamped the output to min|max values whilst retaining the (faulty ?) interpolation.
This commit correctly (in my opinion) interpolates output between min and max values using library functions.

Downside is anyone switching to this code will have to retune their PID parameters. But it is a price I'm willing to pay.