### PR TITLE
Add a few more sensors to schema.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ The following inputs are available:
 - `t_room`: Current sensed room temperature (informational) (°C)  
   Default `min_value`: -40  
   Default `max_value`: 127
+- `max_rel_mod_level`: Maximum relative modulation level (%)  
+  Default `min_value`: 0  
+  Default `max_value`: 127  
+  Supports `auto_min_value`
 <!-- END schema_docs:input -->
 
 ### Switch
@@ -229,4 +233,12 @@ The boiler can also report several numerical values, which are available through
 - `max_t_set_lb`: Lower bound for adjustment of max CH setpoint (°C)
 - `t_dhw_set`: Domestic hot water temperature setpoint (°C)
 - `max_t_set`: Maximum allowable CH water setpoint (°C)
+- `oem_fault_code`: OEM fault code ()
+- `oem_diagnostic_code`: OEM diagnostic code ()
+- `max_capacity`: Maximum boiler capacity (KW) (kW)
+- `min_mod_level`: Minimum modulation level (%)
+- `opentherm_version_slave`: Version of OpenTherm implemented by slave ()
+- `slave_type`: Slave product type ()
+- `slave_version`: Slave product version ()
+- `slave_id`: Slave ID code ()
 <!-- END schema_docs:sensor -->

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -75,7 +75,7 @@ enum MessageId {
   FHB_SIZE = 12,
   FHB_COMMAND = 13,
   MAX_MODULATION_LEVEL = 14,
-  MAX_BOILER_CAPACITY = 15,
+  MAX_BOILER_CAPACITY = 15, // u8_hb - u8_lb gives min modulation level
   ROOM_SETPOINT = 16,
   MODULATION_LEVEL = 17,
   CH_WATER_PRESSURE = 18,

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -5,6 +5,8 @@ from typing import Generic, TypeVar, TypedDict, Optional
 
 from esphome.const import (
     UNIT_CELSIUS,
+    UNIT_EMPTY,
+    UNIT_KILOWATT,
     UNIT_MICROAMP,
     UNIT_PERCENT,
     UNIT_REVOLUTIONS_PER_MINUTE,
@@ -16,6 +18,7 @@ from esphome.const import (
     DEVICE_CLASS_PROBLEM,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_NONE,
     STATE_CLASS_TOTAL_INCREASING,
 )
 
@@ -392,6 +395,103 @@ SENSORS: Schema[SensorSchema] = Schema(
                 "message_data": "f88",
             }
         ),
+
+        "oem_fault_code": SensorSchema(
+            {
+                "description": "OEM fault code",
+                "unit_of_measurement": UNIT_EMPTY,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_NONE,
+                "message": "FAULT_FLAGS",
+                "keep_updated": True,
+                "message_data": "u8_lb",
+            }
+        ),
+        "oem_diagnostic_code": SensorSchema(
+            {
+                "description": "OEM diagnostic code",
+                "unit_of_measurement": UNIT_EMPTY,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_NONE,
+                "message": "OEM_DIAGNOSTIC",
+                "keep_updated": True,
+                "message_data": "u16",
+            }
+        ),
+        "max_capacity": SensorSchema(
+            {
+                "description": "Maximum boiler capacity (KW)",
+                "unit_of_measurement": UNIT_KILOWATT,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_MEASUREMENT,
+                "disabled_by_default": True,
+                "message": "MAX_BOILER_CAPACITY",
+                "keep_updated": False,
+                "message_data": "u8_hb",
+            }
+        ),
+        "min_mod_level": SensorSchema(
+            {
+                "description": "Minimum modulation level",
+                "unit_of_measurement": UNIT_PERCENT,
+                "accuracy_decimals": 0,
+                "icon": "mdi:percent",
+                "disabled_by_default": True,
+                "state_class": STATE_CLASS_MEASUREMENT,
+                "message": "MAX_BOILER_CAPACITY",
+                "keep_updated": False,
+                "message_data": "u8_lb",
+            }
+        ),
+        "opentherm_version_slave": SensorSchema(
+            {
+                "description": "Version of OpenTherm implemented by slave",
+                "unit_of_measurement": UNIT_EMPTY,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_NONE,
+                "disabled_by_default": True,
+                "message": "OT_VERSION_DEVICE",
+                "keep_updated": False,
+                "message_data": "f88",
+            }
+        ),
+        "slave_type": SensorSchema(
+            {
+                "description": "Slave product type",
+                "unit_of_measurement": UNIT_EMPTY,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_NONE,
+                "disabled_by_default": True,
+                "message": "VERSION_DEVICE",
+                "keep_updated": False,
+                "message_data": "u8_hb",
+            }
+        ),
+        "slave_version": SensorSchema(
+            {
+                "description": "Slave product version",
+                "unit_of_measurement": UNIT_EMPTY,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_NONE,
+                "disabled_by_default": True,
+                "message": "VERSION_DEVICE",
+                "keep_updated": False,
+                "message_data": "u8_lb",
+            }
+        ),
+        "slave_id": SensorSchema(
+            {
+                "description": "Slave ID code",
+                "unit_of_measurement": UNIT_EMPTY,
+                "accuracy_decimals": 0,
+                "state_class": STATE_CLASS_NONE,
+                "disabled_by_default": True,
+                "message": "DEVICE_CONFIG",
+                "keep_updated": False,
+                "message_data": "u8_lb",
+            }
+        ),
+
     }
 )
 
@@ -730,5 +830,19 @@ INPUTS: Schema[InputSchema] = Schema(
                 "range": (-40, 127),
             }
         ),
+        "max_rel_mod_level": InputSchema(
+            {
+                "description": "Maximum relative modulation level",
+                "unit_of_measurement": UNIT_PERCENT,
+                "step": 0.1,
+                "icon": "mdi:percent",
+                "message": "MAX_MODULATION_LEVEL",
+                "keep_updated": True,
+                "message_data": "f88",
+                "range": (0, 127),
+                "auto_min_value": { "message": "MaxCapacityMinModLevel", "message_data": "u8_lb" },
+            }
+        ),
+
     }
 )

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -443,9 +443,9 @@ SENSORS: Schema[SensorSchema] = Schema(
                 "message_data": "u8_lb",
             }
         ),
-        "opentherm_version_slave": SensorSchema(
+        "opentherm_version_device": SensorSchema(
             {
-                "description": "Version of OpenTherm implemented by slave",
+                "description": "Version of OpenTherm implemented by device",
                 "unit_of_measurement": UNIT_EMPTY,
                 "accuracy_decimals": 0,
                 "state_class": STATE_CLASS_NONE,
@@ -455,9 +455,9 @@ SENSORS: Schema[SensorSchema] = Schema(
                 "message_data": "f88",
             }
         ),
-        "slave_type": SensorSchema(
+        "device_type": SensorSchema(
             {
-                "description": "Slave product type",
+                "description": "Device product type",
                 "unit_of_measurement": UNIT_EMPTY,
                 "accuracy_decimals": 0,
                 "state_class": STATE_CLASS_NONE,
@@ -467,9 +467,9 @@ SENSORS: Schema[SensorSchema] = Schema(
                 "message_data": "u8_hb",
             }
         ),
-        "slave_version": SensorSchema(
+        "device_version": SensorSchema(
             {
-                "description": "Slave product version",
+                "description": "Device product version",
                 "unit_of_measurement": UNIT_EMPTY,
                 "accuracy_decimals": 0,
                 "state_class": STATE_CLASS_NONE,
@@ -479,9 +479,9 @@ SENSORS: Schema[SensorSchema] = Schema(
                 "message_data": "u8_lb",
             }
         ),
-        "slave_id": SensorSchema(
+        "device_id": SensorSchema(
             {
-                "description": "Slave ID code",
+                "description": "Device ID code",
                 "unit_of_measurement": UNIT_EMPTY,
                 "accuracy_decimals": 0,
                 "state_class": STATE_CLASS_NONE,


### PR DESCRIPTION
Add the following inptut number:
 `max_rel_mod_level`: Maximum relative modulation level

Add the following sensors:
 `oem_fault_code`: OEM fault code
 `oem_diagnostic_code`: OEM diagnostic code
 `max_capacity`: Maximum boiler capacity
 `min_mod_level`: Minimum modulation level
 `opentherm_version_slave`: Version of OpenTherm implemented by slave
 `slave_type`: Slave product type
 `slave_version`: Slave product version
 `slave_id`: Slave ID code