### PR TITLE
State should not be clamped if zero_means_zero is set

### DIFF
--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -6,8 +6,7 @@ namespace opentherm {
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD("opentherm.output", "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
-  state = state < 0.003 && this->zero_means_zero_ ? 0.0 : lerp(state, min_value_, max_value_);
-  this->state = clamp(state, min_value_, max_value_);
+  this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(lerp(state, min_value_, max_value_), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD("opentherm.output", "Output %s set to %.2f", this->id_, this->state);
 }


### PR DESCRIPTION
The functionality of zero_means_zero was changed in a previous commit, such that 0 would still be clamped to the allowed minimum temperature.

For my boiler this means that if the PID controller does not call for heat, it will still keep the pump running and sometimes heat the water, as a constant 20 degrees is requested.

This commit changes that back, such that 0 will request 0.0 from the boiler, causing the boiler to go into stand-by mode.