### PR TITLE
Using stringstream triggers a frequent OOM on an esp8266.

### DIFF
--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -138,7 +138,7 @@ OpenthermHub::OpenthermHub() : Component(), in_pin_{}, out_pin_{} {}
 void OpenthermHub::process_response(OpenthermData &data) {
   ESP_LOGD(TAG, "Received OpenTherm response with id %d (%s)", data.id,
            this->opentherm_->message_id_to_str((MessageId) data.id));
-  ESP_LOGD(TAG, "%s", this->opentherm_->debug_data(data).c_str());
+  this->opentherm_->debug_data(data);
 
   switch (data.id) {
     OPENTHERM_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_RESPONSE_MESSAGE, OPENTHERM_MESSAGE_RESPONSE_ENTITY, ,
@@ -315,7 +315,7 @@ void OpenthermHub::start_conversation_() {
 
   ESP_LOGD(TAG, "Sending request with id %d (%s)", request.id,
            this->opentherm_->message_id_to_str((MessageId) request.id));
-  ESP_LOGD(TAG, "%s", this->opentherm_->debug_data(request).c_str());
+  this->opentherm_->debug_data(request);
   // Send the request
   this->last_conversation_start_ = millis();
   this->opentherm_->send(request);
@@ -344,13 +344,15 @@ void OpenthermHub::stop_opentherm_() {
 void OpenthermHub::handle_protocol_write_error_() {
   ESP_LOGW(TAG, "Error while sending request: %s",
            this->opentherm_->operation_mode_to_str(this->opentherm_->get_mode()));
-  ESP_LOGW(TAG, "%s", this->opentherm_->debug_data(this->last_request_).c_str());
+  this->opentherm_->debug_data(this->last_request_);
 }
 
 void OpenthermHub::handle_protocol_read_error_() {
   OpenThermError error;
   this->opentherm_->get_protocol_error(error);
-  ESP_LOGW(TAG, "Protocol error occured while receiving response: %s", this->opentherm_->debug_error(error).c_str());
+  ESP_LOGW(TAG, "Protocol error occured while receiving response: %s",
+           this->opentherm_->protocol_error_to_to_str(error.error_type));
+  this->opentherm_->debug_error(error);
 }
 
 void OpenthermHub::handle_timeout_error_() {

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -541,13 +541,11 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
   }
 }
 
-std::string OpenTherm::format_bin(const uint8_t *data, size_t length) {
+std::string OpenTherm::format_bin(const uint32_t data, size_t length) const {
   std::string result;
   result.resize(length * 8);
-  for (int byte_idx = 0; byte_idx < length; ++byte_idx) {
-    for (int bit_idx = 0; bit_idx < 8; ++bit_idx) {
-      result[byte_idx * 8 + bit_idx] = (char) ((data[byte_idx] >> bit_idx) & 1 + '0');
-    }
+  for (int idx = 0; idx < (length * 8); idx++) {
+    result[idx] = ((data >> idx) & 1) + '0';
   }
 
   return result;

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -545,29 +545,58 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
   }
 }
 
-string OpenTherm::debug_data(OpenthermData &data) {
-  stringstream result;
-  result << bitset<8>(data.type) << " " << bitset<8>(data.id) << " " << bitset<8>(data.valueHB) << " "
-         << bitset<8>(data.valueLB) << "\n";
-  result << "type: " << this->message_type_to_str((MessageType) data.type) << "; ";
-  result << "id: " << to_string(data.id) << "; ";
-  result << "HB: " << to_string(data.valueHB) << "; ";
-  result << "LB: " << to_string(data.valueLB) << "; ";
-  result << "uint_16: " << to_string(data.u16()) << "; ";
-  result << "float: " << to_string(data.f88());
+static std::string num_to_bin(uint8_t n, int b)
+{
+  std::string s ;
+  for (int i = 0; i < b; i++)
+    {
+      s += (n & 1) +'0';
+      n >>= 1;
+    }
+  return s;
+}
 
-  return result.str();
+std::string OpenTherm::debug_data(OpenthermData &data) {
+
+  std::string result = num_to_bin(data.type, 8);
+  result += " ";
+  result += num_to_bin(data.id, 8);
+  result += " ";
+  result += num_to_bin(data.valueHB, 8);
+  result += " ";
+  result += num_to_bin(data.valueLB, 8);
+
+  result += "\ntype: ";
+  result += this->message_type_to_str((MessageType) data.type);
+  result += "; id: ";
+  result += to_string(data.id);
+  result += "; HB: ";
+  result += to_string(data.valueHB);
+  result += "; LB: ";
+  result += to_string(data.valueLB);
+  result += "; uint_16: ";
+  result += to_string(data.u16());
+  result += "; float: ";
+  result += to_string(data.f88());
+  result += '\0';
+
+  return result;
+
 }
 std::string OpenTherm::debug_error(OpenThermError &error) {
-  stringstream result;
-  result << "type: " << this->protocol_error_to_to_str(error.error_type) << "; ";
-  result << "data: ";
-  result << format_hex(error.data);
-  result << "; clock: " << to_string(clock_);
-  result << "; capture: " << bitset<32>(error.capture);
-  result << "; bit_pos: " << to_string(error.bit_pos);
 
-  return result.str();
+  std::string result = "type ";
+  result += this->protocol_error_to_to_str(error.error_type);
+  result += " data: ";
+  result += format_hex(error.data);
+  result += "; clock: ";
+  result += to_string(clock_);
+  result += "; capture: ";
+  result += num_to_bin(error.capture, 32);
+  result += "; bit_pos: ";
+  result += to_string(error.bit_pos);
+
+  return result.c_str();
 }
 
 float OpenthermData::f88() { return ((float) this->s16()) / 256.0; }

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -545,8 +545,10 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
   }
 }
 
-static std::string num_to_bin(uint8_t n, int b) {
+static std::string num_to_bin(uint32_t n, int b) {
   std::string s;
+  if (b > 32)
+    b = 32;
   for (int i = 0; i < b; i++) {
     s += (n & 1) + '0';
     n >>= 1;
@@ -556,13 +558,13 @@ static std::string num_to_bin(uint8_t n, int b) {
 
 std::string OpenTherm::debug_data(OpenthermData &data) {
 
-  std::string result = num_to_bin(data.type, 8);
+  std::string result = num_to_bin((uint32_t)data.type, 8);
   result += " ";
-  result += num_to_bin(data.id, 8);
+  result += num_to_bin((uint32_t)data.id, 8);
   result += " ";
-  result += num_to_bin(data.valueHB, 8);
+  result += num_to_bin((uint32_t)data.valueHB, 8);
   result += " ";
-  result += num_to_bin(data.valueLB, 8);
+  result += num_to_bin((uint32_t)data.valueLB, 8);
 
   result += "\ntype: ";
   result += this->message_type_to_str((MessageType)data.type);

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -545,14 +545,12 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
   }
 }
 
-static std::string num_to_bin(uint8_t n, int b)
-{
-  std::string s ;
-  for (int i = 0; i < b; i++)
-    {
-      s += (n & 1) +'0';
-      n >>= 1;
-    }
+static std::string num_to_bin(uint8_t n, int b) {
+  std::string s;
+  for (int i = 0; i < b; i++) {
+    s += (n & 1) + '0';
+    n >>= 1;
+  }
   return s;
 }
 
@@ -567,7 +565,7 @@ std::string OpenTherm::debug_data(OpenthermData &data) {
   result += num_to_bin(data.valueLB, 8);
 
   result += "\ntype: ";
-  result += this->message_type_to_str((MessageType) data.type);
+  result += this->message_type_to_str((MessageType)data.type);
   result += "; id: ";
   result += to_string(data.id);
   result += "; HB: ";
@@ -581,7 +579,6 @@ std::string OpenTherm::debug_data(OpenthermData &data) {
   result += '\0';
 
   return result;
-
 }
 std::string OpenTherm::debug_error(OpenThermError &error) {
 

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -541,11 +541,14 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
   }
 }
 
-std::string OpenTherm::format_bin(const uint32_t data, size_t length) const {
+std::string OpenTherm::format_bin(const uint8_t *data, size_t length) {
   std::string result;
   result.resize(length * 8);
-  for (int idx = 0; idx < (length * 8); idx++) {
-    result[idx] = ((data >> idx) & 1) + '0';
+  for (int byte_idx = 0; byte_idx < length; byte_idx++) {
+    for (int bit_idx = 0; bit_idx < 8; ++bit_idx) {
+      result[byte_idx * 8 + bit_idx] =
+          ((data[byte_idx] >> (7 - bit_idx)) & 1) + '0';
+    }
   }
 
   return result;

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -549,7 +549,7 @@ static std::string num_to_bin(uint32_t n, int b) {
   std::string s;
   if (b > 32)
     b = 32;
-  s.resize(d);
+  s.resize(b);
   for (int i = 0; i < b; i++) {
     s += (n & 1) + '0';
     n >>= 1;

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -549,6 +549,7 @@ static std::string num_to_bin(uint32_t n, int b) {
   std::string s;
   if (b > 32)
     b = 32;
+  s.resize(d);
   for (int i = 0; i < b; i++) {
     s += (n & 1) + '0';
     n >>= 1;

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -368,11 +368,15 @@ class OpenTherm {
   ProtocolErrorType verify_stop_bit_(uint8_t value);
   void write_bit_(uint8_t high, uint8_t clock);
 
-  // Format <typename T> in to a binary string
-  template <typename T> std::string format_bin(T val) const {
-    return format_bin((uint32_t)val, sizeof(T));
+  // Format an unsigned integer in binary, starting with the most significant
+  // byte.
+  template <typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0>
+  static std::string format_bin(T val) {
+    return format_bin(reinterpret_cast<uint8_t *>(&val), sizeof(T));
   }
-  std::string format_bin(uint32_t data, size_t length) const;
+
+  // Format the byte array \p data of length \p len in binary
+  static std::string format_bin(const uint8_t *data, size_t length);
 
 #ifdef ESP8266
   // ESP8266 timer can accept callback with no parameters, so we have this hack to save a static instance of OpenTherm

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -8,10 +8,9 @@
 #pragma once
 
 #include <string>
-#include <sstream>
-#include <iomanip>
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 #if defined(ESP32) || defined(USE_ESP_IDF)
 #include "driver/timer.h"
@@ -318,8 +317,8 @@ class OpenTherm {
 
   OperationMode get_mode() { return mode_; }
 
-  std::string debug_data(OpenthermData &data);
-  std::string debug_error(OpenThermError &error);
+  void debug_data(OpenthermData &data);
+  void debug_error(OpenThermError &error) const;
 
   const char *protocol_error_to_to_str(ProtocolErrorType error_type);
   const char *message_type_to_str(MessageType message_type);
@@ -368,6 +367,14 @@ class OpenTherm {
   void bit_read_(uint8_t value);
   ProtocolErrorType verify_stop_bit_(uint8_t value);
   void write_bit_(uint8_t high, uint8_t clock);
+
+  /// Format an unsigned integer in binary, starting with the least significant byte.
+  template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> static std::string format_bin(T val) {
+    return format_bin(reinterpret_cast<uint8_t *>(&val), sizeof(T));
+  }
+
+  /// Format the byte array \p data of length \p len in lowercased hex.
+  static std::string format_bin(const uint8_t *data, size_t length);
 
 #ifdef ESP8266
   // ESP8266 timer can accept callback with no parameters, so we have this hack to save a static instance of OpenTherm

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -368,13 +368,11 @@ class OpenTherm {
   ProtocolErrorType verify_stop_bit_(uint8_t value);
   void write_bit_(uint8_t high, uint8_t clock);
 
-  /// Format an unsigned integer in binary, starting with the least significant byte.
-  template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> static std::string format_bin(T val) {
-    return format_bin(reinterpret_cast<uint8_t *>(&val), sizeof(T));
+  // Format <typename T> in to a binary string
+  template <typename T> std::string format_bin(T val) const {
+    return format_bin((uint32_t)val, sizeof(T));
   }
-
-  /// Format the byte array \p data of length \p len in lowercased hex.
-  static std::string format_bin(const uint8_t *data, size_t length);
+  std::string format_bin(uint32_t data, size_t length) const;
 
 #ifdef ESP8266
   // ESP8266 timer can accept callback with no parameters, so we have this hack to save a static instance of OpenTherm


### PR DESCRIPTION
A string implementation reduces the amount of memory allocations.

Addresses part of the issue: https://github.com/olegtarasov/esphome-opentherm/issues/15