### PR TITLE
Remove potentially unsafe calls from ISR functions.

### DIFF
--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -312,21 +312,12 @@ bool OpenTherm::init_esp32_timer_() {
 }
 
 void IRAM_ATTR OpenTherm::start_esp32_timer_(uint64_t alarm_value) {
-  esp_err_t result;
-
-  result = timer_set_alarm_value(this->timer_group_, this->timer_idx_, alarm_value);
+  esp_err_t result =
+      timer_set_alarm_value(this->timer_group_, this->timer_idx_, alarm_value);
   if (result != ESP_OK) {
-    const auto *error = esp_err_to_name(result);
-    ESP_LOGE(TAG, "Failed to set alarm value. Error: %s", error);
     return;
   }
-
-  result = timer_start(this->timer_group_, this->timer_idx_);
-  if (result != ESP_OK) {
-    const auto *error = esp_err_to_name(result);
-    ESP_LOGE(TAG, "Failed to start the timer. Error: %s", error);
-    return;
-  }
+  timer_start(this->timer_group_, this->timer_idx_);
 }
 
 // 5 kHz timer_
@@ -343,22 +334,11 @@ void IRAM_ATTR OpenTherm::start_write_timer_() {
 
 void IRAM_ATTR OpenTherm::stop_timer_() {
   InterruptLock const lock;
-
-  esp_err_t result;
-
-  result = timer_pause(this->timer_group_, this->timer_idx_);
+  esp_err_t result = timer_pause(this->timer_group_, this->timer_idx_);
   if (result != ESP_OK) {
-    const auto *error = esp_err_to_name(result);
-    ESP_LOGE(TAG, "Failed to pause the timer. Error: %s", error);
     return;
   }
-
-  result = timer_set_counter_value(this->timer_group_, this->timer_idx_, 0);
-  if (result != ESP_OK) {
-    const auto *error = esp_err_to_name(result);
-    ESP_LOGE(TAG, "Failed to set timer counter to 0 after pausing. Error: %s", error);
-    return;
-  }
+  timer_set_counter_value(this->timer_group_, this->timer_idx_, 0);
 }
 
 #endif  // END ESP32


### PR DESCRIPTION
Identified a couple of function calls that I believe are unsafe to call from within interrupts. There is potential for esp_err_to_name() and ESP_LOGx() functions to trigger an illegal call exception as they reside in flash along with the stings that they might use.
In the event of the preceding calls returning an error, I don't think the log messages would be of much use - If I understand the code, calls to the timer functions only return an error if bad data is passed - This would either be a programming error, or the result of memory corruption. And if memory is corrupt, the whole system is toast.